### PR TITLE
Tweak TileLayer loading to load from screen center

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.10.6",
         "@loaders.gl/core": "^3.3.1",
         "@loaders.gl/wkt": "^3.3.1",
+        "@math.gl/core": "^3.6.3",
         "@mui/icons-material": "^5.11.11",
         "@mui/lab": "^5.0.0-alpha.123",
         "@mui/material": "^5.11.13",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@emotion/styled": "^11.10.6",
     "@loaders.gl/core": "^3.3.1",
     "@loaders.gl/wkt": "^3.3.1",
+    "@math.gl/core": "^3.6.3",
     "@mui/icons-material": "^5.11.11",
     "@mui/lab": "^5.0.0-alpha.123",
     "@mui/material": "^5.11.13",

--- a/src/lib/deck/layers/raster-tile-layer.ts
+++ b/src/lib/deck/layers/raster-tile-layer.ts
@@ -1,6 +1,7 @@
 import { BitmapLayerProps } from 'deck.gl/typed';
 
 import { bitmapLayer, tileLayer } from './base';
+import { Tileset2DCentered } from './tileset-2d-centered';
 
 function getBoundsForTile(tileProps) {
   const {
@@ -12,6 +13,7 @@ function getBoundsForTile(tileProps) {
 
 export function rasterTileLayer(bitmapProps: Partial<BitmapLayerProps>, ...props) {
   return tileLayer(props, {
+    TilesetClass: Tileset2DCentered,
     renderSubLayers: (tileProps) =>
       bitmapLayer(
         tileProps,

--- a/src/lib/deck/layers/selectable-mvt-layer.ts
+++ b/src/lib/deck/layers/selectable-mvt-layer.ts
@@ -1,6 +1,7 @@
 import { geoJsonLayer, mvtLayer } from './base';
 import { DataLoaderOptions, dataLoaderLayer } from './data-loader-layer';
 import { TileSelectionLayerOptions, tileSelectionLayer } from './tile-selection-layer';
+import { Tileset2DCentered } from './tileset-2d-centered';
 
 interface SelectableMvtLayerOptions {
   selectionOptions: TileSelectionLayerOptions;
@@ -13,6 +14,7 @@ export function selectableMvtLayer(
 ) {
   return mvtLayer(
     {
+      TilesetClass: Tileset2DCentered,
       binary: false,
       autoHighlight: true,
       highlightColor: [0, 255, 255, 255],

--- a/src/lib/deck/layers/tileset-2d-centered.ts
+++ b/src/lib/deck/layers/tileset-2d-centered.ts
@@ -1,0 +1,51 @@
+import { ZRange } from '@deck.gl/geo-layers/typed/tileset-2d';
+import { TileIndex } from '@deck.gl/geo-layers/typed/tileset-2d/types';
+import { Matrix4 } from '@math.gl/core';
+import { Viewport, _Tileset2D } from 'deck.gl/typed';
+import _ from 'lodash';
+
+/**
+ * Simple extension of Tileset2D that returns tiles in a changed order:
+ * the tiles closer to the middle of the viewport are returned first, so that the tile loading doesn't happen from the top-left corner of the map.
+ * This assumes the base OSM indexing system.
+ */
+export class Tileset2DCentered extends _Tileset2D {
+  getTileIndices(props: {
+    viewport: Viewport;
+    maxZoom?: number;
+    minZoom?: number;
+    zRange: ZRange;
+    tileSize?: number;
+    modelMatrix?: Matrix4;
+    modelMatrixInverse?: Matrix4;
+    zoomOffset?: number;
+  }): TileIndex[] {
+    const indices = super.getTileIndices(props);
+    let minY = +Infinity,
+      maxY = -Infinity,
+      minX = +Infinity,
+      maxX = -Infinity;
+
+    for (const { x, y } of indices) {
+      if (x < minX) {
+        minX = x;
+      }
+      if (x > maxX) {
+        maxX = x;
+      }
+      if (y < minY) {
+        minY = y;
+      }
+      if (y > maxY) {
+        maxY = y;
+      }
+    }
+
+    const midX = minX + (maxX + 1 - minX) / 2;
+    const midY = minY + (maxY + 1 - minY) / 2;
+
+    return _.sortBy(indices, ({ x, y }) =>
+      Math.sqrt(Math.pow(x + 0.5 - midX, 2) + Math.pow(y + 0.5 - midY, 2)),
+    );
+  }
+}


### PR DESCRIPTION
By default, deck.gl loads tiles (raster, MVT etc) starting from the top left corner of the current viewport.
On a slow connection, this is not ideal, especially when zooming, or using a slider to load new layers (e.g. for hazard return periods). The most interesting region which is in the center of the view can take a while to load.

This simple change, which replaces the default `Tileset2D` class with an extended one for all tile layers used in the application, sorts the tiles to load by their distance from the center of all visible tiles. This is not exactly the distance from the screen center, but should serve as a good-enough approximation.