### PR TITLE
49 and 50 return period damages improvements

### DIFF
--- a/src/details/features/damages/ExpectedDamagesSection.tsx
+++ b/src/details/features/damages/ExpectedDamagesSection.tsx
@@ -160,7 +160,14 @@ export const ExpectedDamagesSection = () => {
                   {...eadChartProps}
                 />
               </Box>
-            ) : null}
+            ) : (
+              <Box mt={1}>
+                <Typography variant="body2">
+                  Indirect damages (losses) due to disruption of infrastructure services (loss of
+                  power, transport disruption) are not yet available.
+                </Typography>
+              </Box>
+            )}
             <Box mt={1}>
               <DamageTable damages={selectedData} />
             </Box>

--- a/src/details/features/damages/RPDamageTable.tsx
+++ b/src/details/features/damages/RPDamageTable.tsx
@@ -1,4 +1,12 @@
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+} from '@mui/material';
 
 import { numFormat, numRangeFormat } from '@/lib/helpers';
 
@@ -25,7 +33,14 @@ export const RPDamageTable = ({ damages }) => (
       <TableBody>
         {damages.map((d) => (
           <TableRow key={d.key}>
-            <TableCell sx={padding}>{d.rp}</TableCell>
+            <Tooltip
+              title={`Probability: ${d.rp === 0 ? 0 : 1 / d.rp}`}
+              arrow
+              placement="left"
+              followCursor
+            >
+              <TableCell sx={padding}>{d.rp}</TableCell>
+            </Tooltip>
             <TableCell sx={{ pl: 0, pr: padding.px, py: padding.py }}>{d.rcp}</TableCell>
             <TableCell sx={padding} align="right">
               {numFormat(d.damage_mean)}

--- a/src/details/features/damages/RPDamagesSection.tsx
+++ b/src/details/features/damages/RPDamagesSection.tsx
@@ -18,6 +18,7 @@ import {
   selectedEpochState,
   selectedHazardState,
   selectedRpOptionState,
+  SHOW_ALL_OPTION,
 } from './param-controls';
 import { ReturnPeriodDamageChart } from './ReturnPeriodDamageChart';
 import { RPDamageTable } from './RPDamageTable';
@@ -119,7 +120,7 @@ const filteredTableDataState = selector({
       return null;
     }
 
-    if (!selectedRpOption || selectedRpOption === 'Show All') {
+    if (!selectedRpOption || selectedRpOption === SHOW_ALL_OPTION) {
       return selectedRpData;
     }
 

--- a/src/details/features/damages/RPDamagesSection.tsx
+++ b/src/details/features/damages/RPDamagesSection.tsx
@@ -124,7 +124,7 @@ const filteredTableDataState = selector({
       return selectedRpData;
     }
 
-    return selectedRpData.filter((x) => x.rp === +selectedRpOption);
+    return selectedRpData.filter((dataRow) => dataRow.rp === +selectedRpOption);
   },
 });
 

--- a/src/details/features/damages/RPDamagesSection.tsx
+++ b/src/details/features/damages/RPDamagesSection.tsx
@@ -12,7 +12,13 @@ import {
   orderDamages,
   QUIRKY_FIELDS_MAPPING,
 } from './DamagesSection';
-import { EpochSelect, selectedEpochState, selectedHazardState } from './param-controls';
+import {
+  EpochSelect,
+  ReturnPeriodSelect,
+  selectedEpochState,
+  selectedHazardState,
+  selectedRpOptionState,
+} from './param-controls';
 import { ReturnPeriodDamageChart } from './ReturnPeriodDamageChart';
 import { RPDamageTable } from './RPDamageTable';
 
@@ -90,7 +96,7 @@ const rpDamageDataState = selector({
   },
 });
 
-const selectedRpDataState = selector({
+export const selectedRpDataState = selector({
   key: 'DamagesSection/selectedRpDataState',
   get: ({ get }) => {
     const selectedHazard = get(selectedHazardState);
@@ -103,10 +109,29 @@ const selectedRpDataState = selector({
   },
 });
 
+const filteredTableDataState = selector({
+  key: 'DamagesSection/filteredTableDataState',
+  get: ({ get }) => {
+    const selectedRpOption = get(selectedRpOptionState);
+    const selectedRpData = get(selectedRpDataState);
+
+    if (!selectedRpData) {
+      return null;
+    }
+
+    if (!selectedRpOption || selectedRpOption === 'Show All') {
+      return selectedRpData;
+    }
+
+    return selectedRpData.filter((x) => x.rp === +selectedRpOption);
+  },
+});
+
 export const RPDamagesSection = () => {
   const fd = useRecoilValue(featureState);
   const returnPeriodDamagesData = useRecoilValue(rpDamageDataState);
   const selectedRPData = useRecoilValue(selectedRpDataState);
+  const filteredTableData = useRecoilValue(filteredTableDataState);
 
   return (
     <Box py={2}>
@@ -138,7 +163,8 @@ export const RPDamagesSection = () => {
               height={150}
               renderer="svg"
             />
-            <RPDamageTable damages={selectedRPData} />
+            <ReturnPeriodSelect />
+            <RPDamageTable damages={filteredTableData} />
           </>
         ) : (
           <Typography variant="body2" color="textSecondary">

--- a/src/details/features/damages/ReturnPeriodDamageChart.tsx
+++ b/src/details/features/damages/ReturnPeriodDamageChart.tsx
@@ -18,9 +18,9 @@ const makeSpec = (rpValues: number[], field_key: string, field_title: string) =>
   },
   encoding: {
     x: {
-      field: 'probability',
+      field: 'rp',
       type: 'quantitative',
-      title: 'Probability',
+      title: 'Return Period (Years)',
       axis: {
         gridDash: [2, 2],
         domainColor: '#ccc',

--- a/src/details/features/damages/param-controls.tsx
+++ b/src/details/features/damages/param-controls.tsx
@@ -65,6 +65,8 @@ export const EpochSelect = () => {
   ) : null;
 };
 
+export const SHOW_ALL_OPTION = 'Show All';
+
 const rpOptionsState = selector({
   key: 'DamagesSection/rpOptionsState',
   get: ({ get }) => {
@@ -72,7 +74,7 @@ const rpOptionsState = selector({
 
     return selectedRpData
       ? [
-          'Show All',
+          SHOW_ALL_OPTION,
           ...unique(
             selectedRpData
               .map((row) => row.rp)
@@ -98,7 +100,7 @@ export const ReturnPeriodSelect = () => {
       <InputLabel>Return Period</InputLabel>
       <Select
         label="Return Period"
-        value={selectedRpOption ?? 'Show All'}
+        value={selectedRpOption ?? SHOW_ALL_OPTION}
         onChange={(e) => setSelectedRpOption(e.target.value as string)}
       >
         {rpOptions.map((h) => (

--- a/src/details/features/damages/param-controls.tsx
+++ b/src/details/features/damages/param-controls.tsx
@@ -7,6 +7,7 @@ import { makeSelectState } from '@/lib/recoil/make-state/make-select-state';
 import { HAZARDS_METADATA } from '@/config/hazards/metadata';
 
 import { damagesDataState } from './ExpectedDamagesSection';
+import { selectedRpDataState } from './RPDamagesSection';
 
 export const hazardsState = selector({
   key: 'DamagesSection/hazardsState',
@@ -57,6 +58,52 @@ export const EpochSelect = () => {
         {epochs.map((h) => (
           <MenuItem key={h} value={h}>
             {titleCase(h)}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  ) : null;
+};
+
+const rpOptionsState = selector({
+  key: 'DamagesSection/rpOptionsState',
+  get: ({ get }) => {
+    const selectedRpData = get(selectedRpDataState);
+
+    return selectedRpData
+      ? [
+          'Show All',
+          ...unique(
+            selectedRpData
+              .map((row) => row.rp)
+              .sort((a, b) => a - b)
+              .map((rp) => rp.toString()),
+          ),
+        ]
+      : [];
+  },
+});
+
+export const selectedRpOptionState = makeSelectState(
+  'DamagesSection/selectedRpOption',
+  rpOptionsState,
+);
+
+export const ReturnPeriodSelect = () => {
+  const rpOptions = useRecoilValue(rpOptionsState);
+  const [selectedRpOption, setSelectedRpOption] = useRecoilState(selectedRpOptionState);
+
+  return rpOptions.length ? (
+    <FormControl fullWidth disabled={rpOptions.length === 1}>
+      <InputLabel>Return Period</InputLabel>
+      <Select
+        label="Return Period"
+        value={selectedRpOption ?? 'Show All'}
+        onChange={(e) => setSelectedRpOption(e.target.value as string)}
+      >
+        {rpOptions.map((h) => (
+          <MenuItem key={h} value={h}>
+            {titleCase(h.toString())}
           </MenuItem>
         ))}
       </Select>

--- a/src/details/features/damages/param-controls.tsx
+++ b/src/details/features/damages/param-controls.tsx
@@ -79,7 +79,7 @@ const rpOptionsState = selector({
             selectedRpData
               .map((row) => row.rp)
               .sort((a, b) => a - b)
-              .map((rp) => rp.toString()),
+              .map(String),
           ),
         ]
       : [];
@@ -96,16 +96,16 @@ export const ReturnPeriodSelect = () => {
   const [selectedRpOption, setSelectedRpOption] = useRecoilState(selectedRpOptionState);
 
   return rpOptions.length ? (
-    <FormControl fullWidth disabled={rpOptions.length === 1}>
+    <FormControl fullWidth disabled={rpOptions.length < 2}>
       <InputLabel>Return Period</InputLabel>
       <Select
         label="Return Period"
         value={selectedRpOption ?? SHOW_ALL_OPTION}
         onChange={(e) => setSelectedRpOption(e.target.value as string)}
       >
-        {rpOptions.map((h) => (
-          <MenuItem key={h} value={h}>
-            {titleCase(h.toString())}
+        {rpOptions.map((rpOption) => (
+          <MenuItem key={rpOption} value={rpOption}>
+            {titleCase(rpOption)}
           </MenuItem>
         ))}
       </Select>


### PR DESCRIPTION
Linked issues: #49, #50 

The RP filter defaults to "Show All", including in the case where the selected the RP is not available (e.g., when switching to a new segment). This select state behaviour should be consistent with the hazard and epoch drop-downs, as it uses the same method from make-select-state.ts. However, the options are derived from the selectedRpDataState, rather than the damagesDataState, to ensure that only the unique options corresponding to a given segment's Return Period Damages table are present.

As discussed for #50, only the EAEL alternate text was applicable, since there is no RPL placeholder chart.