### PR TITLE
63 map only loads top left square on apple m1

### DIFF
--- a/src/map/use-basemap-style.ts
+++ b/src/map/use-basemap-style.ts
@@ -48,7 +48,7 @@ export function useBasemapStyle(
       sources: {},
       layers: [],
     },
-  } = useFetch(BASEMAP_STYLE_URL, { suspense: true });
+  } = useFetch(BASEMAP_STYLE_URL, { suspense: false });
 
   useEffect(() => {
     get();

--- a/src/map/use-basemap-style.ts
+++ b/src/map/use-basemap-style.ts
@@ -48,7 +48,7 @@ export function useBasemapStyle(
       sources: {},
       layers: [],
     },
-  } = useFetch(BASEMAP_STYLE_URL, { suspense: false });
+  } = useFetch(BASEMAP_STYLE_URL);
 
   useEffect(() => {
     get();


### PR DESCRIPTION
Suspense option is "experimental" according to https://www.npmjs.com/package/use-http, so seems sensible to remove it.

The other fix (redrawing the map after component render) is easy to implement, if it's preferred we stay with suspense=true.