### PR TITLE
Use feature `id` instead of `string_id` as key in NBS ranking table

### DIFF
--- a/src/config/nbs/components/FeatureAdaptationsTable.tsx
+++ b/src/config/nbs/components/FeatureAdaptationsTable.tsx
@@ -79,7 +79,7 @@ export const FeatureAdaptationsTable: FC<{
         }
         renderRow={(feature, localIndex, globalIndex) => (
           <ExpandableRow
-            key={feature.string_id}
+            key={feature.id}
             expanded={feature === selectedFeature}
             onExpandedChange={(expanded) => setSelectedFeature(expanded ? feature : null)}
             onMouseEnter={() => setBoundedFeature(feature)}


### PR DESCRIPTION
Previously, `feature.string_id` was used for the row `key` prop. But as some features in the data seem to have identical `string_id` fields - this was leading to corrupted table DOM due to duplicate keys.